### PR TITLE
make ctx a map[string]any

### DIFF
--- a/pkg/handlerruntime/responses.go
+++ b/pkg/handlerruntime/responses.go
@@ -1,9 +1,9 @@
 package handlerruntime
 
 type Data struct {
-	ID    string                 `mapstructure:"id"`
-	Name  string                 `mapstructure:"name"`
-	Other map[string]interface{} `mapstructure:",remain"`
+	ID    string         `mapstructure:"id"`
+	Name  string         `mapstructure:"name"`
+	Other map[string]any `mapstructure:",remain"`
 }
 
 type Resource struct {
@@ -15,7 +15,7 @@ type LoadResourceResponse struct {
 	Resources []Resource `mapstructure:"resources"`
 
 	Tasks []struct {
-		Name string      `mapstructure:"name"`
-		Ctx  interface{} `mapstructure:"ctx"`
+		Name string         `mapstructure:"name"`
+		Ctx  map[string]any `mapstructure:"ctx"`
 	} `mapstructure:"tasks"`
 }


### PR DESCRIPTION
in the PDK CLI we are accidentally providing a context.Context object
to the Ctx field - this commit prevents that