### PR TITLE
use structs for client calls

### DIFF
--- a/pkg/handlerclient/runtime.go
+++ b/pkg/handlerclient/runtime.go
@@ -16,8 +16,8 @@ type Client struct {
 	Executor Executor
 }
 
-func (r *Client) FetchResources(ctx context.Context, name string, contx map[string]any) (*msg.LoadResponse, error) {
-	response, err := r.Executor.Execute(ctx, msg.LoadResources{Task: name, Ctx: contx})
+func (r *Client) FetchResources(ctx context.Context, req msg.LoadResources) (*msg.LoadResponse, error) {
+	response, err := r.Executor.Execute(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +47,8 @@ func (r *Client) Describe(ctx context.Context) (*providerregistrysdk.DescribeRes
 	return &dr, nil
 }
 
-func (r *Client) Grant(ctx context.Context, subject string, target msg.Target) (*msg.GrantResponse, error) {
-	response, err := r.Executor.Execute(ctx, msg.Grant{Subject: subject, Target: target})
+func (r *Client) Grant(ctx context.Context, req msg.Grant) (*msg.GrantResponse, error) {
+	response, err := r.Executor.Execute(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (r *Client) Grant(ctx context.Context, subject string, target msg.Target) (
 	return &gr, nil
 }
 
-func (r *Client) Revoke(ctx context.Context, subject string, target msg.Target) error {
-	_, err := r.Executor.Execute(ctx, msg.Revoke{Subject: subject, Target: target})
+func (r *Client) Revoke(ctx context.Context, req msg.Revoke) error {
+	_, err := r.Executor.Execute(ctx, req)
 	return err
 }

--- a/pkg/handlerclient/runtime_test.go
+++ b/pkg/handlerclient/runtime_test.go
@@ -42,7 +42,7 @@ func TestRuntime_FetchResources(t *testing.T) {
 			}
 			ctx := context.Background()
 
-			got, err := r.FetchResources(ctx, "", map[string]any{})
+			got, err := r.FetchResources(ctx, msg.LoadResources{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Runtime.FetchResources() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -87,7 +87,7 @@ func TestRuntime_Grant(t *testing.T) {
 			}
 			ctx := context.Background()
 
-			got, err := r.Grant(ctx, "", msg.Target{})
+			got, err := r.Grant(ctx, msg.Grant{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Runtime.FetchResources() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
simpler than passing multiple arguments, also saves needing to update this package a second time when changing APIs (as I have done in v0.8.0)