### PR TITLE
update types for provider schema

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -257,13 +257,13 @@ components:
         publisher:
           title: Publisher
           type: string
-        schema_version:
-          title: Schema Version
+        version:
+          title: Version
           type: string
       required:
         - publisher
         - name
-        - schema_version
+        - version
       title: Provider
       type: object
     Resources:
@@ -327,6 +327,10 @@ components:
     Schema:
       description: The schema for a Common Fate Provider.
       properties:
+        $id:
+          type: string
+        $schema:
+          type: string
         config:
           additionalProperties:
             $ref: "#/components/schemas/Config"
@@ -347,6 +351,8 @@ components:
           type: object
       required:
         - meta
+        - $id
+        - $schema
       title: Schema
       type: object
   requestBodies: {}

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,15 +1,15 @@
 openapi: 3.0.0
 info:
   title: Common Fate Provider Registry
-  version: '1.0'
+  version: "1.0"
   contact:
     name: Common Fate
-    url: 'https://api.registry.commonfate.io'
+    url: "https://api.registry.commonfate.io"
   description: The Common Fate Provider Registry API.
 servers:
-  - url: 'http://localhost:9001'
+  - url: "http://localhost:9001"
 paths:
-  '/v1alpha1/providers/{publisher}/{name}/{version}':
+  "/v1alpha1/providers/{publisher}/{name}/{version}":
     parameters:
       - schema:
           type: string
@@ -30,19 +30,19 @@ paths:
       summary: Get Provider
       operationId: get-provider
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProviderDetail'
-        '404':
-          $ref: '#/components/responses/ErrorResponse'
-        '500':
-          $ref: '#/components/responses/ErrorResponse'
+                $ref: "#/components/schemas/ProviderDetail"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
       tags:
         - Public
-  '/v1alpha1/providers/{publisher}/{name}/{version}/setup':
+  "/v1alpha1/providers/{publisher}/{name}/{version}/setup":
     parameters:
       - schema:
           type: string
@@ -63,7 +63,7 @@ paths:
       summary: Get Provider Setup Docs
       operationId: get-provider-setup-docs
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -73,7 +73,7 @@ paths:
                   type: string
       tags:
         - Public
-  '/v1alpha1/providers/{publisher}/{name}/{version}/usage':
+  "/v1alpha1/providers/{publisher}/{name}/{version}/usage":
     parameters:
       - schema:
           type: string
@@ -94,7 +94,7 @@ paths:
       summary: Get Provider Usage Doc
       operationId: get-provider-usage-doc
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -104,17 +104,17 @@ paths:
                   type: string
       tags:
         - Public
-      description: ''
+      description: ""
   /v1alpha1/providers:
     get:
       summary: List Providers
       tags:
         - Public
       responses:
-        '200':
-          $ref: '#/components/responses/ListProvidersResponse'
-        '500':
-          $ref: '#/components/responses/ErrorResponse'
+        "200":
+          $ref: "#/components/responses/ListProvidersResponse"
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
       operationId: list-all-providers
 components:
   schemas:
@@ -136,7 +136,7 @@ components:
         cfnTemplateS3Arn:
           type: string
         schema:
-          $ref: '#/components/schemas/Schema'
+          $ref: "#/components/schemas/Schema"
       required:
         - publisher
         - name
@@ -270,7 +270,7 @@ components:
       properties:
         loaders:
           additionalProperties:
-            $ref: '#/components/schemas/Loader'
+            $ref: "#/components/schemas/Loader"
           x-go-type: map[string]Loader
           title: Loaders
           type: object
@@ -287,7 +287,7 @@ components:
       properties:
         properties:
           additionalProperties:
-            $ref: '#/components/schemas/TargetField'
+            $ref: "#/components/schemas/TargetField"
           x-go-type: map[string]TargetField
           description: the actual properties of the target.
           title: Properties
@@ -309,7 +309,7 @@ components:
           title: Description
           type: string
         resource:
-          description: 'If specified, the type of the resource the field should be populated from.'
+          description: "If specified, the type of the resource the field should be populated from."
           title: Resource
           type: string
         title:
@@ -329,19 +329,19 @@ components:
       properties:
         config:
           additionalProperties:
-            $ref: '#/components/schemas/Config'
+            $ref: "#/components/schemas/Config"
           x-go-type: map[string]Config
           title: Config
           type: object
         meta:
-          $ref: '#/components/schemas/Meta'
+          $ref: "#/components/schemas/Meta"
         provider:
-          $ref: '#/components/schemas/Provider'
+          $ref: "#/components/schemas/Provider"
         resources:
-          $ref: '#/components/schemas/Resources'
+          $ref: "#/components/schemas/Resources"
         targets:
           additionalProperties:
-            $ref: '#/components/schemas/Target'
+            $ref: "#/components/schemas/Target"
           x-go-type: map[string]Target
           title: Targets
           type: object
@@ -385,7 +385,7 @@ components:
               providers:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ProviderDetail'
+                  $ref: "#/components/schemas/ProviderDetail"
               next:
                 type: string
                 nullable: true

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,15 +1,15 @@
 openapi: 3.0.0
 info:
   title: Common Fate Provider Registry
-  version: "1.0"
+  version: '1.0'
   contact:
     name: Common Fate
-    url: "https://api.registry.commonfate.io"
+    url: 'https://api.registry.commonfate.io'
   description: The Common Fate Provider Registry API.
 servers:
-  - url: "http://localhost:9001"
+  - url: 'http://localhost:9001'
 paths:
-  "/v1alpha1/providers/{publisher}/{name}/{version}":
+  '/v1alpha1/providers/{publisher}/{name}/{version}':
     parameters:
       - schema:
           type: string
@@ -30,19 +30,19 @@ paths:
       summary: Get Provider
       operationId: get-provider
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProviderDetail"
-        "404":
-          $ref: "#/components/responses/ErrorResponse"
-        "500":
-          $ref: "#/components/responses/ErrorResponse"
+                $ref: '#/components/schemas/ProviderDetail'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
       tags:
         - Public
-  "/v1alpha1/providers/{publisher}/{name}/{version}/setup":
+  '/v1alpha1/providers/{publisher}/{name}/{version}/setup':
     parameters:
       - schema:
           type: string
@@ -63,7 +63,7 @@ paths:
       summary: Get Provider Setup Docs
       operationId: get-provider-setup-docs
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
@@ -73,7 +73,7 @@ paths:
                   type: string
       tags:
         - Public
-  "/v1alpha1/providers/{publisher}/{name}/{version}/usage":
+  '/v1alpha1/providers/{publisher}/{name}/{version}/usage':
     parameters:
       - schema:
           type: string
@@ -94,7 +94,7 @@ paths:
       summary: Get Provider Usage Doc
       operationId: get-provider-usage-doc
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
@@ -104,17 +104,17 @@ paths:
                   type: string
       tags:
         - Public
-      description: ""
+      description: ''
   /v1alpha1/providers:
     get:
       summary: List Providers
       tags:
         - Public
       responses:
-        "200":
-          $ref: "#/components/responses/ListProvidersResponse"
-        "500":
-          $ref: "#/components/responses/ErrorResponse"
+        '200':
+          $ref: '#/components/responses/ListProvidersResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
       operationId: list-all-providers
 components:
   schemas:
@@ -136,7 +136,7 @@ components:
         cfnTemplateS3Arn:
           type: string
         schema:
-          $ref: "#/components/schemas/ProviderSchema"
+          $ref: '#/components/schemas/Schema'
       required:
         - publisher
         - name
@@ -161,154 +161,6 @@ components:
         - publisher
         - name
         - version
-    ConfigArgument:
-      title: ConfigArgument
-      x-stoplight:
-        id: b867e439e8b53
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - string
-        secret:
-          type: boolean
-        description:
-          type: string
-      required:
-        - type
-        - secret
-        - description
-    TargetArgument:
-      title: TargetArgument
-      x-stoplight:
-        id: 1b080aa3276c2
-      type: object
-      description: "Defines the metadata and data type for the argument"
-      properties:
-        id:
-          type: string
-        title:
-          type: string
-        description:
-          type: string
-        resource:
-          type: string
-      required:
-        - id
-        - title
-    ProviderSchema:
-      title: ProviderSchema
-      x-stoplight:
-        id: d3gvj3cbsoe70
-      type: object
-      properties:
-        $schema:
-          type: string
-        $id:
-          type: string
-        config:
-          $ref: "#/components/schemas/ConfigSchema"
-        resources:
-          $ref: "#/components/schemas/ResourcesSchema"
-        targets:
-          $ref: "#/components/schemas/TargetSchema"
-        meta:
-          $ref: "#/components/schemas/MetaSchema"
-      required:
-        - $schema
-        - $id
-    TargetKind:
-      title: TargetKind
-      x-stoplight:
-        id: o2oindupo85hh
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - "object"
-        properties:
-          x-go-type: map[string]TargetArgument
-          type: object
-          additionalProperties:
-            $ref: "#/components/schemas/TargetArgument"
-      required:
-        - properties
-        - type
-    TargetSchema:
-      title: TargetSchema
-      x-go-type: map[string]TargetKind
-      x-stoplight:
-        id: tk7obmea4shbx
-      type: object
-      additionalProperties:
-        $ref: "#/components/schemas/TargetKind"
-    ConfigSchema:
-      title: ConfigSchema
-      x-go-type: map[string]ConfigArgument
-      x-stoplight:
-        id: a4b73cf497883
-      type: object
-      additionalProperties:
-        $ref: "#/components/schemas/ConfigArgument"
-    ResourcesSchema:
-      title: ResourcesSchema
-      x-stoplight:
-        id: bacx4ke9fh1bo
-      type: object
-      properties:
-        loaders:
-          type: object
-          x-go-type: map[string]ResourceLoader
-          additionalProperties:
-            $ref: "#/components/schemas/ResourceLoader"
-        types:
-          type: object
-          x-go-type: map[string]Resource
-          additionalProperties:
-            $ref: "#/components/schemas/Resource"
-      required:
-        - loaders
-    MetaSchema:
-      title: MetaSchema
-      type: object
-      x-stoplight:
-        id: a23a6233affd6
-      properties:
-        framework:
-          type: string
-      required:
-        - framework
-      description: Metadata about the schema
-    ResourceLoader:
-      title: ResourceLoader
-      x-stoplight:
-        id: j3ehgrwrocbeh
-      type: object
-      properties:
-        title:
-          type: string
-      required:
-        - title
-    Resource:
-      title: Resource
-      type: object
-      x-stoplight:
-        id: b9183456d960d
-      properties:
-        type:
-          type: string
-        data:
-          type: object
-          required:
-            - id
-          properties:
-            id:
-              type: string
-      required:
-        - type
-        - data
     DiagnosticLog:
       title: DiagnosticLog
       x-stoplight:
@@ -339,7 +191,7 @@ components:
           items:
             $ref: "#/components/schemas/DiagnosticLog"
         schema:
-          $ref: "#/components/schemas/ProviderSchema"
+          $ref: "#/components/schemas/Schema"
       required:
         - provider
         - config
@@ -355,6 +207,148 @@ components:
         - INFO
         - ERROR
         - WARNING
+    Config:
+      properties:
+        description:
+          description: The usage for the config variable.
+          title: Description
+          type: string
+        secret:
+          default: false
+          title: Secret
+          type: boolean
+        type:
+          enum:
+            - string
+          title: Type
+          type: string
+      required:
+        - type
+      title: Config
+      type: object
+    Loader:
+      description: |-
+        A callable function in the provider which can
+        load resources.
+
+        Additional fields for loader configuration may be added
+        in a future specification.
+      properties:
+        title:
+          title: Title
+          type: string
+      required:
+        - title
+      title: Loader
+      type: object
+    Meta:
+      properties:
+        framework:
+          description: The Provider Developer Kit framework version which published the schema.
+          title: Framework
+          type: string
+      title: Meta
+      type: object
+    Providers:
+      properties:
+        name:
+          title: Name
+          type: string
+        publisher:
+          title: Publisher
+          type: string
+        schema_version:
+          title: Schema Version
+          type: string
+      required:
+        - publisher
+        - name
+        - schema_version
+      title: Provider
+      type: object
+    Resources:
+      properties:
+        loaders:
+          additionalProperties:
+            $ref: '#/components/schemas/Loader'
+          x-go-type: map[string]Loader
+          title: Loaders
+          type: object
+        types:
+          description: the types of resources
+          title: Types
+          type: object
+      required:
+        - loaders
+        - types
+      title: Resources
+      type: object
+    Target:
+      properties:
+        properties:
+          additionalProperties:
+            $ref: '#/components/schemas/TargetField'
+          x-go-type: map[string]TargetField
+          description: the actual properties of the target.
+          title: Properties
+          type: object
+        type:
+          description: included for compatibility with JSON Schema - all targets are currently objects.
+          enum:
+            - object
+          title: Type
+          type: string
+      required:
+        - type
+        - properties
+      title: Target
+      type: object
+    TargetField:
+      properties:
+        description:
+          title: Description
+          type: string
+        resource:
+          description: 'If specified, the type of the resource the field should be populated from.'
+          title: Resource
+          type: string
+        title:
+          title: Title
+          type: string
+        type:
+          enum:
+            - string
+          title: Type
+          type: string
+      required:
+        - type
+      title: TargetField
+      type: object
+    Schema:
+      description: The schema for a Common Fate Provider.
+      properties:
+        config:
+          additionalProperties:
+            $ref: '#/components/schemas/Config'
+          x-go-type: map[string]Config
+          title: Config
+          type: object
+        meta:
+          $ref: '#/components/schemas/Meta'
+        provider:
+          $ref: '#/components/schemas/Provider'
+        resources:
+          $ref: '#/components/schemas/Resources'
+        targets:
+          additionalProperties:
+            $ref: '#/components/schemas/Target'
+          x-go-type: map[string]Target
+          title: Targets
+          type: object
+      required:
+        - meta
+      title: Schema
+      type: object
   requestBodies: {}
   responses:
     HealthResponse:
@@ -391,7 +385,7 @@ components:
               providers:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ProviderDetail"
+                  $ref: '#/components/schemas/ProviderDetail'
               next:
                 type: string
                 nullable: true

--- a/pkg/providerregistrysdk/api.gen.go
+++ b/pkg/providerregistrysdk/api.gen.go
@@ -112,9 +112,9 @@ type ProviderDetail struct {
 
 // Providers defines model for Providers.
 type Providers struct {
-	Name          string `json:"name"`
-	Publisher     string `json:"publisher"`
-	SchemaVersion string `json:"schema_version"`
+	Name      string `json:"name"`
+	Publisher string `json:"publisher"`
+	Version   string `json:"version"`
 }
 
 // Resources defines model for Resources.
@@ -127,6 +127,8 @@ type Resources struct {
 
 // The schema for a Common Fate Provider.
 type Schema struct {
+	Id     string             `json:"$id"`
+	Schema string             `json:"$schema"`
 	Config *map[string]Config `json:"config,omitempty"`
 	Meta   Meta               `json:"meta"`
 
@@ -1112,34 +1114,34 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZXW/bNhf+KwTf91L1R9N2iO+CpumyZkngZNtFYww0dWSxpUiVpNIYhv/7QIqSKEuO",
-	"lTQDBmxXseXzxec85/DoZIOpzHIpQBiNZxusQOdSaHBfPigl1dw/sQ+oFAaEsR9JnnNGiWFSjL9oKewz",
-	"TVPIiP2UK5mDMqy0A9aO/WDWOeAZ1kYxscLbbYQVfCuYghjPPnuxRVSJyeUXoAZvrVwMmiqWW3d4hk8E",
-	"csJIgSmUgBglSmbIpIBOrs9HeBvhn4Fwk75A8KkztA7CX0rJgYhO/JXkkBOU4dEU6FdUYY6WMl674C+Y",
-	"NtdK3rMYlH6BMwh4cDqi4JwsOeCZUQVEu/mIrFrp1EozA5n78H8FCZ7h/40broxLV3pchXkKhjBubXij",
-	"RCmy7mDUOIjKqIaA9eGBZDmHGihn1Qdg43svRcJW3WO3rOx8xbcpoEKTFaBEKkcd6syge6KYBWmEI2yY",
-	"sWjh00C1BzYNVIEpfSSk4AbPEsI1NAZuSomow6HqyQaDKDILkTe7aJRvrUR0oHrcr4GSB6UDb+QPs4SQ",
-	"WG3gaA1oRzlmZCWkNowO58hprXMhV12KRI/VWMPJoUzENTkOadyUUvs4iqMKiCbCNgC1o8UuVQJ0dzMQ",
-	"4YdX2sics1XqOMNii4VJEiJeLx8mx8fKhdRGrZMjDvfAD53wQq4unNw2wpleHe7BpdVSODxUK5ZhJ3r4",
-	"9rZI9UPOMj4tG8GFJD6PO+0cUVI2JpQUgtqniAlXk1Uu0PeU0RRRIu4ElyS2vUAWioIe3Yk7cRLHzKoR",
-	"jhIGPNauqLnz5+u6UK5Xooys0RIQiWOI7wQTiKCkMIUCpHOgLPE91VZ/G3CPxaYpS/f3YF06qQBLj0JP",
-	"YdbZCrrB+eXZFY7wh/n8ao4j/MfJ/PL88mPbntfajaQ/LeqYwoORX+Ij8+4nF+2vYHrujESRDL5L9bW/",
-	"dVbVhk6tb6uIPjGDai10D0pbvMvE5cWSM51C7LJa0jNssGe1tz48KykXaQ9w10GL2KWWghXTBhTEDZl8",
-	"bJ0UC5JBT41EuApf9f5amTtYXY2ZqPTV6AYJvW76z5A6W76Jj6fTKZkmyet3zuXOnfyDoNBE3EKWc2Lg",
-	"5uhEiV4IOMmWMTnRGsx+oWfC+7Rm/jLp6DlR1EWir//vgD+w+8fHSzh6Fy9hctzOoe6Z5ioYvcfLMvQD",
-	"qFbhBWfeg/SfIYDV/OJ+Qb/X8DwZ2R3bQ/i+jfC8avM9F6Dro+4jqdv/dUvk8auR+GGh3Zh1b8pW8pV/",
-	"mJH8c3nqRWBinfeMnNj2OvcTkklzY+H2ZNd12LmUW4HpELt5aHQXvJu6cLr9u4TBXZMEvZdZJgU6I6Zp",
-	"7N0LsJkKn4O3n0e3ByfUvXA3FjJ/Yz3mz90VzxwfVci6x5Qa+O25iFqBeTYhb516CNCtNzgYocrEDn8c",
-	"XAFpPC96GOMNdGqt/e35pzuzwxnuvODZOiHUFISjxpOtGVdATjMcFgKvT4Sm9l+9dLXjYILyIobYlYU9",
-	"BDFsyTgza/SdmRT9cnN1iXwrfIUI5z44jYgCRAulQBi+RmUw2sZczXE+vme91bUKcbHLj/15LE976LV4",
-	"4DtuVRNd1M6TanSGOEJVz6vSV+m5L244RzqVBY/tFJ7LvLDXabnACXNcVVZfKEMn8b/t3TqEt3d/wUQi",
-	"q30Noaa5tXHQanGEC8XxDKfG5Ho2HpOcjcrJTK1H1AkmxMCIyW7J2B7e17bR3BsoN2Fht31EOJh8Zng6",
-	"mlh/MgdBcoZn+Gg0GU0sC4lJHYPG91PC85RMx62FkW8dlmvuHercjjYXTJsTzq+DxU9ryfh6MtnXO2q5",
-	"cf9CbBvht0O023tMtzwqsoyotQ8PhcEZstI2525QonhhxXvOO97UM852vLHJ3Y43HsPtXjA+ggmmnT4c",
-	"Bm/4nrKU667Urj5Z9N5M3jwZvRfA/CM0kPchbplm3weN49XnDWY2ZMu+apyctSbMplTLtWYDUqese201",
-	"Q/+PWvKz7nAzi2ewa6zBFPkQjt1YwVNJ9Y+SrV7z7emw9ba3l2h7k49cgMhH+B8PnsgDt74ewoPfrOCp",
-	"pP9UGrj4UBngv5sF7p8J6r46ajMfzMZjLinhqdRmdjyZTPF2UYNVTxceNBuPf3ILJMPbxfavAAAA//+m",
-	"wGwn6RsAAA==",
+	"H4sIAAAAAAAC/+xZ3W7buBJ+FYKnl6plN20P4rugaXpymk0CJ7t70fiCpkYWW4pUSSqNYejdF6SoP0uO",
+	"lTQFFti9iizNH7/5ZjhktpjKNJMChNF4vsUKdCaFBvfjo1JSLfwb+4JKYUAY+0iyjDNKDJMi/KqlsO80",
+	"TSAl9ilTMgNlWGkHrB37YDYZ4DnWRjGxxkURYAXfc6YgwvMvXmwZVGJy9RWowYWVi0BTxTLrDs/xiUBO",
+	"GCkwuRIQoVjJFJkE0Mn1+QQXAf4fEG6SFwg+cYY2rfBXUnIgohd/JTlmBWV4NAH6DVWYo5WMNi74C6bN",
+	"tZL3LAKlX2ANAh6cjsg5JysOeG5UDsFuPgKrVjq10sxA6h5eKYjxHP8nbLgSlq50WIV5CoYwbm14o0Qp",
+	"sulh1DgIyqjGgPXxgaQZhxooZ9UHYOP7IEXM1v1ld6zs/MS3CaBckzWgWCpHHerMoHuimAVpggNsmLFo",
+	"4dOW6gBsGqgCU/qISc4NnseEa2gM3JQSQY9D1ZstBpGnFiJvdtko31qJ4ED1uK8tJQ9KD97AL2YFbWJ1",
+	"gaM1oD3liJG1kNowOp4jp7XOhVz3KRI8VmMNJ8cyEdfkOKRxU0rt4ygOKiCaCLsA1I6Wu1RpobubgQA/",
+	"vNZGZpytE8cZFlksTBwT8Wb1MD0+Vi6kLmq9HHG4B35ohRdyfeHkigCnen24B5dWS+H2ojqxjFvRw/d3",
+	"eaIfMpbyWdkILiTxedxp54iSsjGhOBfUvkVMuJqscoF+JIwmiBJxJ7gkke0FMlcU9ORO3ImTKGJWjXAU",
+	"M+CRdkXNnT9f17lyvRKlZINWgEgUQXQnmEAExbnJFSCdAWWx76m2+ruAeyy2TVm6vwfr0km1sPQoDBRm",
+	"na1WNzi/PLvCAf64WFwtcID/PFlcnl9+6trzWruRDKdFHVN4MPJrdGTe/9dF+xuYgT0jViSFH1J9G26d",
+	"VbWhU+vbKqLPzKBaC92D0hbvMnFZvuJMJxC5rJb0bDfYs9rbEJ6VlIt0ALjrVovYpZaCNdMGFEQNmXxs",
+	"vRQLksJAjQS4Cl8Nfq3MHayuxkxQ+mp0Wwm9bvrPmDpbvY2OZ7MZmcXxm/fO5c6e/JOg0FjcQppxYuDm",
+	"6ESJQQg4SVcROdEazH6hZ8L7tGb+MukYWFHQR2Ko/++AP7L7R8crOHofrWB63M2hHpjmKhi9x8sy9AOo",
+	"VuG11vwokb38HzUgv5TaRYAXVUcf2Otcy3SPpO701x2Rx3dB4ueCbg/Wg9lZy9f+ZUqyL+Vyly0Tm2xg",
+	"usS2rblPSMbN5oS7Q1zfYW//7QSm29gt2kZ3wbupa6TfqksY3I5I0AeZplKgM2KaHt7f615ZVg6U4qum",
+	"FnvfmqHxOTny42pxcIDdm6LGQuo3tMf8ua3kmdOlajP1MaUmZXZdRK3BPJvEt069DdCtNzgaocrEDufS",
+	"cle1OW8y3CKe59YA67zBXr12fz1/tWd2lsO986CtNUJNTjhqPNm6c0XoNNuzRcvrE6Gq/VdntG4cTFCe",
+	"RxC50rKLIIatGGdmg34wk6D/31xdohI99BoRzn1wGhEFiOZKgTB8g8pgtI25Gvt8fM86BHaKebnLl/15",
+	"LFd76BQ98khc1UgftfO4mrQhClDVN6v0VXruh5vlkU5kziM7tGcyy+3uW973tHNcVdpQKGMH9192FG/D",
+	"O3jdwUQsq+sdQk2zyeNWu8YBzhXHc5wYk+l5GJKMTcpBTm0m1AnGxMCEyX7J2H1gqPWjhTdQXpy1u+8j",
+	"wq3NfY5nk6n1JzMQJGN4jo8m08nUspCYxDEovJ8RniVkFnbul3zrsFxzR65zOwldMG1OOL9u3RN17iTf",
+	"TKf7ekctFw7fnxUBfjdGu3vt6e6a8jQlauPDQ+3gDFlrm3M3V1G8tOID6w239YBUhFub3CLcegyLvWB8",
+	"AtOamIZwGH0h+JQ7vP4N3NVni97b6dsno/cCmH+CBvIhxC3T7PHROF592WJmQ7bsq2bReWc8bUq1vAXd",
+	"O9MUwaCt5ozws5b8oDzezPIZ7Ao1mDwbw7EbK3gqqf5ZstW3gns6bH05PEi0vclHLkDkI/yXB0/kgbvt",
+	"HsOD363gqaR/Vxq4+FAZ4D+bBe5/D+q+WmozH8zDkEtKeCK1mR9PpzNcLGuw6unCg2bj8W9ugaS4WBZ/",
+	"BQAA///Np/s/GBwAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
This pull request changes some types based on the new provider schema

We probably want to refine this approach and prefix or suffix the models here with the schema version like Resource_v1alpha1

Note that these changes have not been pulled into any of the other repos