### PR TITLE
use env var for registry URL

### DIFF
--- a/pkg/registryclient/client.go
+++ b/pkg/registryclient/client.go
@@ -1,4 +1,4 @@
-package client
+package registryclient
 
 import (
 	"context"


### PR DESCRIPTION
avoids regressions where registry is updated to localhost in development